### PR TITLE
lecture2 title

### DIFF
--- a/02-requirements/02-requirements.tex
+++ b/02-requirements/02-requirements.tex
@@ -3,8 +3,8 @@
 
 \documentclass{article}
 \usepackage{../ssd}
-\newcommand*\thetitle{README}
-\newcommand*\thesubtitle{vs. IEEE, RUP, SWEBOK, CMMI}
+\newcommand*\thetitle{Requirements}
+\newcommand*\thesubtitle{Engineering}
 \begin{document}
 
 \innoTitlePage{2}


### PR DESCRIPTION
Changed the title in lecture 2 (02-requirements.tex) from "README vs. IEEE, RUP, SWEBOK, CMMI" back to  "Requirements Engineering" which appears to better match the document's actual content about software requirements.