### PR TITLE
Fix missing `aspell.en.pws` file reference error

### DIFF
--- a/.texsc
+++ b/.texsc
@@ -1,4 +1,4 @@
---pws=../aspell.en.pws
+--pws=../lecture-notes/aspell.en.pws
 --ignore=href,ffcode
 --ignore=ff,nospell,citet,citep
 --ignore=pptPic:pp

--- a/00-intro/.texsc
+++ b/00-intro/.texsc
@@ -1,4 +1,4 @@
---pws=../aspell.en.pws
+--pws=../lecture-notes/aspell.en.pws
 --ignore=href,ffcode
 --ignore=ff,nospell,citet,citep
 --ignore=pptPic:pp

--- a/01-readme/.texsc
+++ b/01-readme/.texsc
@@ -1,4 +1,4 @@
---pws=../aspell.en.pws
+--pws=../lecture-notes/aspell.en.pws
 --ignore=href,ffcode
 --ignore=ff,nospell,citet,citep
 --ignore=pptPic:pp

--- a/02-requirements/.texsc
+++ b/02-requirements/.texsc
@@ -1,4 +1,4 @@
---pws=../aspell.en.pws
+--pws=../lecture-notes/aspell.en.pws
 --ignore=href,ffcode
 --ignore=ff,nospell,citet,citep
 --ignore=pptPic:pp

--- a/03-rup/.texsc
+++ b/03-rup/.texsc
@@ -1,4 +1,4 @@
---pws=../aspell.en.pws
+--pws=../lecture-notes/aspell.en.pws
 --ignore=href,ffcode
 --ignore=ff,nospell,citet,citep
 --ignore=pptPic:pp

--- a/04-ooad/.texsc
+++ b/04-ooad/.texsc
@@ -1,4 +1,4 @@
---pws=../aspell.en.pws
+--pws=../lecture-notes/aspell.en.pws
 --ignore=href,ffcode
 --ignore=ff,nospell,citet,citep
 --ignore=pptPic:pp

--- a/05-objects/.texsc
+++ b/05-objects/.texsc
@@ -1,4 +1,4 @@
---pws=../aspell.en.pws
+--pws=../lecture-notes/aspell.en.pws
 --ignore=href,ffcode
 --ignore=ff,nospell,citet,citep
 --ignore=pptPic:pp

--- a/06-patterns/.texsc
+++ b/06-patterns/.texsc
@@ -1,4 +1,4 @@
---pws=../aspell.en.pws
+--pws=../lecture-notes/aspell.en.pws
 --ignore=href,ffcode
 --ignore=ff,nospell,citet,citep
 --ignore=pptPic:pp

--- a/07-xml/.texsc
+++ b/07-xml/.texsc
@@ -1,4 +1,4 @@
---pws=../aspell.en.pws
+--pws=../lecture-notes/aspell.en.pws
 --ignore=href,ffcode
 --ignore=ff,nospell,citet,citep
 --ignore=pptPic:pp

--- a/08-uml/.texsc
+++ b/08-uml/.texsc
@@ -1,4 +1,4 @@
---pws=../aspell.en.pws
+--pws=../lecture-notes/aspell.en.pws
 --ignore=href,ffcode
 --ignore=ff,nospell,citet,citep
 --ignore=pptPic:pp

--- a/09-sql/.texsc
+++ b/09-sql/.texsc
@@ -1,4 +1,4 @@
---pws=../aspell.en.pws
+--pws=../lecture-notes/aspell.en.pws
 --ignore=href,ffcode
 --ignore=ff,nospell,citet,citep
 --ignore=pptPic:pp

--- a/10-ci/.texsc
+++ b/10-ci/.texsc
@@ -1,4 +1,4 @@
---pws=../aspell.en.pws
+--pws=../lecture-notes/aspell.en.pws
 --ignore=href,ffcode
 --ignore=ff,nospell,citet,citep
 --ignore=pptPic:pp

--- a/11-api/.texsc
+++ b/11-api/.texsc
@@ -1,4 +1,4 @@
---pws=../aspell.en.pws
+--pws=../lecture-notes/aspell.en.pws
 --ignore=href,ffcode
 --ignore=ff,nospell,citet,citep
 --ignore=pptPic:pp

--- a/12-cloud/.texsc
+++ b/12-cloud/.texsc
@@ -1,4 +1,4 @@
---pws=../aspell.en.pws
+--pws=../lecture-notes/aspell.en.pws
 --ignore=href,ffcode
 --ignore=ff,nospell,citet,citep
 --ignore=pptPic:pp

--- a/13-tdd/.texsc
+++ b/13-tdd/.texsc
@@ -1,4 +1,4 @@
---pws=../aspell.en.pws
+--pws=../lecture-notes/aspell.en.pws
 --ignore=href,ffcode
 --ignore=ff,nospell,citet,citep
 --ignore=pptPic:pp

--- a/14-tests/.texsc
+++ b/14-tests/.texsc
@@ -1,4 +1,4 @@
---pws=../aspell.en.pws
+--pws=../lecture-notes/aspell.en.pws
 --ignore=href,ffcode
 --ignore=ff,nospell,citet,citep
 --ignore=pptPic:pp

--- a/15-metrics/.texsc
+++ b/15-metrics/.texsc
@@ -1,4 +1,4 @@
---pws=../aspell.en.pws
+--pws=../lecture-notes/aspell.en.pws
 --ignore=href,ffcode
 --ignore=ff,nospell,citet,citep
 --ignore=pptPic:pp

--- a/16-future/.texsc
+++ b/16-future/.texsc
@@ -1,4 +1,4 @@
---pws=../aspell.en.pws
+--pws=../lecture-notes/aspell.en.pws
 --ignore=href,ffcode
 --ignore=ff,nospell,citet,citep
 --ignore=pptPic:pp

--- a/syllabus/.texsc
+++ b/syllabus/.texsc
@@ -1,4 +1,4 @@
---pws=../aspell.en.pws
+--pws=../lecture-notes/aspell.en.pws
 --ignore=href,ffcode
 --ignore=ff,nospell,citet,citep
 --ignore=pptPic:pp


### PR DESCRIPTION
This pull request fixes the error `ERROR: The PWS file '.../ssd16/aspell.en.pws' is not found` by updating the reference to the correct `aspell.en.pws` file located in the `lecture-notes` submodule.