### PR TITLE
Update `.rultor.yml` to use `lecture-notes/tlmgr-install.sh`

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -3,12 +3,9 @@
 ---
 # yamllint disable rule:line-length
 docker:
-  image: yegor256/rultor-image:1.24.0
+  image: yegor256/latex
 install: |-
-  sudo tlmgr option repository ctan
-  sudo tlmgr --verify-repo=none update --self
-  sudo tlmgr --verify-repo=none install $(cut -d' ' -f2 DEPENDS.txt | uniq)
-  sudo tlmgr --verify-repo=none update $(cut -d' ' -f2 DEPENDS.txt | uniq)
+  sudo lecture-notes/tlmgr-install.sh
 merge:
   script: |-
     make


### PR DESCRIPTION
This pull request updates Rultor configuration to use `lecture-notes/tlmgr-install.sh` script for installing LaTeX packages and changes the Docker image to `yegor256/latex`.

Related to issue #12.
