### PR TITLE
Fix `typos` workflow

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,2 @@
+[default.extend-words]
+RTO = "RTO"


### PR DESCRIPTION
`crate-ci/typos@v1.32.0` action [flags](https://github.com/yegor256/ssd16/actions/runs/14909574987/job/41880313196) "RTO" from

https://github.com/yegor256/ssd16/blob/e0754a617b0b1292c0d16c17d12c8d1456923a7f/02-requirements/02-requirements.tex#L94

as a misspelling. This update ensures "RTO" is recognized as a valid term.